### PR TITLE
Update Kotlin-Components

### DIFF
--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -26,25 +26,31 @@ kmpConfiguration {
     setupMultiplatform(
         setOf(
 
-            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_11),
+            KmpTarget.Jvm.Jvm.DEFAULT,
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,
-                browser = KmpTarget.NonJvm.JS.Browser(
-                    jsBrowserDsl = null
-                ),
-                node = KmpTarget.NonJvm.JS.Node(
-                    jsNodeDsl = null
-                ),
-                mainSourceSet = null,
-                testSourceSet = null,
+                browser = KmpTarget.NonJvm.JS.Browser(),
+                node = KmpTarget.NonJvm.JS.Node(),
             ),
 
-            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.All.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.All.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.All.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 
             KmpTarget.NonJvm.Native.Unix.Linux.X64.DEFAULT,
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,5 @@ kotlin.mpp.stability.nowarn=true
 
 kotlin.native.binary.memoryModel=experimental
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info


### PR DESCRIPTION
Updates Kotlin-Components, which:
 - Refactors KmpTargets
 - Refactors source set names
 - Adds support for remaining platforms
 - Removes gradle property `kotlin.mpp.enableCompatibilityMetadataVariant=true` in favor of Kotlin `1.6.21`'s hierarchical support